### PR TITLE
fix: Set null

### DIFF
--- a/api/lbp.js
+++ b/api/lbp.js
@@ -109,7 +109,7 @@ async function userPostCommitRequest(requestSessionToken) {
     const timestamp = new Date().getTime().toString()
     const nonce = timestamp.slice(-8)
     const signature = generateSignature(nonce, timestamp, 'POST', uri, null)
-    const lbpResp = await axios.post(url, {}, {
+    const lbpResp = await axios.post(url, null, {
         headers: {
             timestamp,
             'service-api-key': _apiKey,


### PR DESCRIPTION
Because "content-length" doesn't become 0 when "{}" is used

I got the message:

>  ERROR  index.js - request-commit - catch {"message":"Request failed with status code 400","name":"Error","stack":"Error: Request failed with status code 400

And I checked `config.data` and `response.data` when the  error happen

```
config: {
    data: '{}'
}
```
```
  data: {
    responseTime: 1608563523334,
    statusCode: 4000,
    statusMessage: 'Bad request: Content-Length should be 0 or be excluded'
  }
```
```
"Content-Length":2
```